### PR TITLE
Travis setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,4 @@ script:
 
 after_success:
   - codecov
+  - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: python
+python:
+  - "3.6"
+
+script:
+  - pip install -U pip setuptools
+  - pip install -e .[test]
+  - cd tests && pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,8 @@ python:
 
 script:
   - pip install -U pip setuptools
-  - pip install -e .[test]
-  - cd tests && pytest
+  - pip install -e .[ci]
+  - cd tests && pytest --cov --cov-report term
+
+after_success:
+  - codecov

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,10 @@ extra_test = [
 ]
 extra_dev = extra_test
 
+extra_ci = extra_test + [
+    'codecov',
+]
+
 setup(
     name='django-outer-join',
 
@@ -24,6 +28,8 @@ setup(
     extras_require={
         'test': extra_test,
         'dev': extra_dev,
+
+        'ci': extra_ci,
     },
 
     packages=find_packages(),

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ extra_dev = extra_test
 
 extra_ci = extra_test + [
     'codecov',
+    'python-coveralls',
 ]
 
 setup(


### PR DESCRIPTION
Setup travis, codecov and coveralls. Resolves #2 

Codecov does not pick up `__init__.py` in the source root, which contains the majority of the code, so it should not be used until it is fixed. (https://github.com/codecov/codecov-python/issues/136)