### PR TITLE
fix makemigrations errors caused by composite pk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ dist/
 .eggs/
 .pytest_cache/
 .coverage
+.makemigrations
 
 # Mac
 .DS_Store

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_script:
   - cd tests
 
 script:
-  - python manage.py makemigrations > .makemigrations && [[ "$(cat .makemigrations)" == "No changes detected" ]]
+  - ./test-migrations.sh
   - pytest --cov --cov-report term
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,13 @@
 language: python
+
 python:
   - "3.6"
+
+cache: pip
+
+services:
+  - postgresql
+
 env:
   - DJANGO_VERSION=2.0.*
   - DJANGO_VERSION=2.1.*
@@ -11,8 +18,13 @@ install:
   - pip install -U "Django==${DJANGO_VERSION}"
   - pip install -e .[ci]
 
+before_script:
+  - psql -c 'CREATE DATABASE django_outer_join_test;' -U postgres
+  - cd tests
+
 script:
-  - cd tests && pytest --cov --cov-report term
+  - python manage.py makemigrations > .makemigrations && [[ "$(cat .makemigrations)" == "No changes detected" ]]
+  - pytest --cov --cov-report term
 
 after_success:
   - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_script:
   - cd tests
 
 script:
-  - ./test-migrations.sh
+  - ./test-makemigrations.sh
   - pytest --cov --cov-report term
 
 after_success:

--- a/README.md
+++ b/README.md
@@ -188,8 +188,9 @@ primary_key = outer_join.get_primary_key()()
 
 * `get_primary_key -> Type[Field]`
     * `base_class: Type[Field]`
-        * Default is `CharField`.
+        * Default is `TextField`.
         * You can replace this with a field type, e.g. `SlugField`. However, validation is probably not guaranteed (not tested).
+        * `primary_key` is set to `True`. You can only have one primary key field in a model, obviously.
     * `*`
     * `format_pk: Callable[[Tuple], str]`
         * Used to format a pk for objects selected from database.

--- a/outer_join/__init__.py
+++ b/outer_join/__init__.py
@@ -226,7 +226,7 @@ class OuterJoin(OuterJoinInterceptor):
             table_name: str = None,
     ) -> _typing.Optional['OuterJoin']:
         for instance in cls.__ALL:
-            if model is not None and model is not instance.model.raw:
+            if model is not None and instance.model != model:
                 continue
             if table_name is not None and table_name != instance.model.table_name:
                 continue
@@ -273,7 +273,7 @@ class OuterJoin(OuterJoinInterceptor):
             if outer_join.pk is None:
                 outer_join.__pk = _FieldInfo(field)
                 return
-            if field is outer_join.pk.raw:
+            if outer_join.pk == field:
                 return
             raise _errors.MultiplePKDeclared
 
@@ -366,7 +366,7 @@ class OuterJoin(OuterJoinInterceptor):
                     result = [
                         col
                         for col in result
-                        if col.field is not outer_join.pk.raw
+                        if outer_join.pk != col.field
                     ]
                 return result
 
@@ -378,7 +378,7 @@ class OuterJoin(OuterJoinInterceptor):
 
             def _compile_col(self, node: _Col, *, select_format):
                 field = node.target
-                if field.model is not outer_join.model.raw:
+                if outer_join.model != field.model:
                     return super().compile(node, select_format=select_format)
 
                 name = field.name

--- a/outer_join/__init__.py
+++ b/outer_join/__init__.py
@@ -262,7 +262,7 @@ class OuterJoin(OuterJoinInterceptor):
 
     def get_primary_key(
             self,
-            base_class: _typing.Type[_models.Field] = _models.CharField,
+            base_class: _typing.Type[_models.Field] = _models.TextField,
             *,
             format_pk: _typing.Callable[[_typing.Iterable], str] = _hyphen_join,
             parse_pk: _typing.Callable[[str], _typing.Iterable] = _hyphen_split,
@@ -270,10 +270,12 @@ class OuterJoin(OuterJoinInterceptor):
         outer_join = self
 
         def set_pk(field):
-            if outer_join.__pk is not None:
-                raise _errors.MultiplePKDeclared
-            outer_join.__pk = _FieldInfo(field)
-            pass
+            if outer_join.pk is None:
+                outer_join.__pk = _FieldInfo(field)
+                return
+            if field is outer_join.pk.raw:
+                return
+            raise _errors.MultiplePKDeclared
 
         class PKField(base_class):
             def __init__(self, *args, **kwargs):

--- a/outer_join/util/info.py
+++ b/outer_join/util/info.py
@@ -1,6 +1,9 @@
 import typing as _typing
 
 import django.db.models as _models
+from django.db.models.base import (
+    ModelBase as _ModelBase,
+)
 from django.db.models.expressions import (
     Col as _Col,
 )
@@ -26,6 +29,21 @@ from .. import (
 class ModelInfo(object):
     def __init__(self, model: _typing.Type[_models.Model]):
         self.__raw = model
+
+    def __eq__(self, other):
+        if isinstance(other, ModelInfo):
+            return self == other.raw
+        if not isinstance(other, (_models.Model, _ModelBase)):
+            return False
+
+        raw = self.raw
+        if raw == other:
+            return True
+
+        if raw._meta.label != other._meta.label:
+            return False
+
+        return True
 
     @property
     def raw(self) -> _typing.Type[_models.Model]:
@@ -122,6 +140,23 @@ class FieldInfo(object):
         if model is None:
             model = ModelInfo(field.model)
         self.__model = model
+
+    def __eq__(self, other):
+        if isinstance(other, FieldInfo):
+            return self == other.raw
+        if not isinstance(other, _models.Field):
+            return False
+
+        raw = self.raw
+        if raw == other:
+            return True
+
+        if self.model != other.model:
+            return False
+        if raw.name != other.name:
+            return False
+
+        return True
 
     @property
     def raw(self) -> _models.Field:

--- a/tests/test-makemigrations.sh
+++ b/tests/test-makemigrations.sh
@@ -5,6 +5,7 @@ django_version="$(python -c "import django; print(django.__version__[:3])")"
 if [[ "${django_version}" == "2.0" ]]
 then
     # django 2.0 requires NullBooleanField instead of BooleanField(null=True)
+    echo "Using django 2.0, skipping"
     exit 0
 fi
 
@@ -14,12 +15,16 @@ python manage.py makemigrations > ${result}
 code=$?
 if [[ ${code} != 0 ]]
 then
+    echo "makemigrations exited with ${code}"
     exit ${code}
 fi
 
-if [[ "$(cat ${result})" == "No changes detected" ]]
+expect="No changes detected"
+if [[ "$(cat ${result})" == "${expect}" ]]
 then
     exit 0
 else
+    echo "makemigrations is not clean (expect '${expect}'):"
+    cat ${result}
     exit 2
 fi

--- a/tests/test-migrations.sh
+++ b/tests/test-migrations.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+django_version="$(python -c "import django; print(django.__version__[:3])")"
+
+if [[ "${django_version}" == "2.0" ]]
+then
+    # django 2.0 requires NullBooleanField instead of BooleanField(null=True)
+    exit 0
+fi
+
+result=".makemigrations"
+python manage.py makemigrations > ${result}
+
+code=$?
+if [[ ${code} != 0 ]]
+then
+    exit ${code}
+fi
+
+if [[ "$(cat ${result})" == "No changes detected" ]]
+then
+    exit 0
+else
+    exit 2
+fi


### PR DESCRIPTION
* change default to `TextField` (doesn't require `max_length`)
* improve equality check for models and fields
* add `makemigrations` test to ci
* cache pip in ci